### PR TITLE
Add analyze command

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+var analyzeCmd = &cobra.Command{
+	Use:   "analyze",
+	Short: "Analyze kubernetes data from the boltdb '.db' files etcd persists to.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return analyzeValidateAndRun()
+	},
+}
+
+type analyzeOptions struct {
+	filename string
+}
+
+var analyzeOpts *analyzeOptions = &analyzeOptions{}
+
+func init() {
+	RootCmd.AddCommand(analyzeCmd)
+	analyzeCmd.Flags().StringVarP(&analyzeOpts.filename, "file", "f", "", "Bolt DB '.db' filename")
+}
+
+func analyzeValidateAndRun() error {
+	summaries, err := listKeySummaries(analyzeOpts.filename, "")
+	if err != nil {
+		return err
+	}
+
+	objectCounts := map[string]uint{}
+	for _, s := range summaries {
+		if s.TypeMeta != nil {
+			objectCounts[fmt.Sprintf("%s/%s", s.TypeMeta.APIVersion, s.TypeMeta.Kind)] += 1
+		}
+	}
+
+	type entry struct {
+		count uint
+		gvk   string
+	}
+
+	entries := []entry{}
+	for k, v := range objectCounts {
+		entries = append(entries, entry{gvk: k, count: v})
+	}
+
+	sort.Slice(entries[:], func(i, j int) bool {
+		return entries[i].count > entries[j].count
+	})
+
+	var totalKeySize int
+	var totalValueSize int
+	var totalAllVersionsKeySize int
+	var totalAllVersionsValueSize int
+	for _, summary := range summaries {
+		totalKeySize += summary.Stats.KeySize
+		totalValueSize += summary.Stats.ValueSize
+		totalAllVersionsKeySize += summary.Stats.AllVersionsKeySize
+		totalAllVersionsValueSize += summary.Stats.AllVersionsValueSize
+	}
+
+	fmt.Printf("Total kubernetes objects: %d\n", len(summaries))
+	fmt.Printf("Total (all revisions) storage used by kubernetes objects: %d\n", totalAllVersionsKeySize+totalAllVersionsValueSize)
+	fmt.Printf("Current (latest revision) storage used by kubernetes objects: %d\n", totalKeySize+totalValueSize)
+	fmt.Printf("\n")
+	fmt.Printf("Most common kubernetes types:\n")
+	for i, entry := range entries {
+		fmt.Printf("\t%d\t%s\n", entry.count, entry.gvk)
+		if i > 10 {
+			break
+		}
+	}
+
+	sort.Slice(summaries[:], func(i, j int) bool {
+		return summaries[i].Stats.AllVersionsValueSize > summaries[j].Stats.AllVersionsValueSize
+	})
+	fmt.Printf("\n")
+	fmt.Printf("Largest objects (byte size sum of all revisions):\n")
+	for i, summary := range summaries {
+		fmt.Printf("\t%d\t%s (%s/%s)\n", summary.Stats.AllVersionsValueSize, summary.Key, summary.TypeMeta.APIVersion, summary.TypeMeta.Kind)
+		if i > 10 {
+			break
+		}
+	}
+
+	return nil
+}

--- a/cmd/decode.go
+++ b/cmd/decode.go
@@ -23,10 +23,11 @@ import (
 	"os"
 
 	"bufio"
+	"bytes"
 	"encoding/hex"
+
 	"github.com/kubernetes-incubator/auger/pkg/encoding"
 	"github.com/spf13/cobra"
-	"bytes"
 )
 
 var (
@@ -151,7 +152,7 @@ func runInBatchMode(metaOnly bool, outMediaType string, out io.Writer) (err erro
 		}
 
 		buf := bytes.NewBufferString("")
-		err = encoding.Convert(inMediaType, outMediaType, decodedinput, buf)
+		_, err = encoding.Convert(inMediaType, outMediaType, decodedinput, buf)
 		if err != nil {
 			fmt.Fprintf(out, "ERROR:%v|\n", err)
 		} else {
@@ -160,7 +161,6 @@ func runInBatchMode(metaOnly bool, outMediaType string, out io.Writer) (err erro
 
 		lineNum++
 	}
-	return nil
 }
 
 // Run the decode command line.
@@ -174,7 +174,8 @@ func run(metaOnly bool, outMediaType string, in []byte, out io.Writer) error {
 		return encoding.DecodeSummary(inMediaType, in, out)
 	}
 
-	return encoding.Convert(inMediaType, outMediaType, in, out)
+	_, err = encoding.Convert(inMediaType, outMediaType, in, out)
+	return err
 }
 
 // Readinput reads command line input, either from a provided input file or from stdin.

--- a/cmd/encode.go
+++ b/cmd/encode.go
@@ -80,5 +80,6 @@ func encodeValidateAndRun() error {
 
 // encodeRun runs the encode command.
 func encodeRun(inMediaType string, in []byte, out io.Writer) error {
-	return encoding.Convert(inMediaType, encoding.StorageBinaryMediaType, in, out)
+	_, err := encoding.Convert(inMediaType, encoding.StorageBinaryMediaType, in, out)
+	return err
 }


### PR DESCRIPTION
`analyze` prints out a high level summary of a etcd db file including counts of the most common object types and largest objects in the db as well as some aggregate stats about the file.