### PR TITLE
Quick fix to make Auger work with CRDs.

### DIFF
--- a/cmd/decode_test.go
+++ b/cmd/decode_test.go
@@ -75,10 +75,10 @@ func assertMatchesFile(t *testing.T, out *bytes.Buffer, filename string) {
 ==== BEGIN RECIEVED FILE ====
 %s
 ====END RECIEVED FILE ====
-====BEGIN EXPECTED FILE ====
+====BEGIN EXPECTED FILE (%s) ====
 %s
 ==== END EXPECTED FILE ====
-`, len(b), len(expected), b, expected)
+`, len(b), len(expected), b, filename, expected)
 	}
 }
 


### PR DESCRIPTION
CR data is always JSON and cannot be coverted to other media type.
Assumes user asks for it as JSON and then shortcuts conversion.

For example :
auger extract -f db -k /registry/ark.heptio.com/deletebackuprequests/heptio-ns/heptio-backup-cr -o json --fields value