### PR TITLE
Add spaces around assignment operators (resolves #32)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-NAME?=auger
-PKG?=github.com/jpbetz/$(NAME)
-GO_VERSION?=1.16.5
-GOOS?=linux
-GOARCH?=amd64
-TEMP_DIR:=$(shell mktemp -d)
+NAME ?= auger
+PKG ?= github.com/jpbetz/$(NAME)
+GO_VERSION ?= 1.16.5
+GOOS ?= linux
+GOARCH ?= amd64
+TEMP_DIR := $(shell mktemp -d)
 
 # Local development build
 build:


### PR DESCRIPTION
# Add spaces around assignment operators (resolves #32)
Add spaces around the assignment operators.

Before:
```Makefile
NAME?=auger 
PKG?=github.com/jpbetz/$(NAME) 
GO_VERSION?=1.16.5 
GOOS?=linux 
GOARCH?=amd64 
TEMP_DIR:=$(shell mktemp -d) 
...
```

Now:
```Makefile
NAME ?= auger
PKG ?= github.com/jpbetz/$(NAME)
GO_VERSION ?= 1.16.5
GOOS ?= linux
GOARCH ?= amd64
TEMP_DIR := $(shell mktemp -d)
...
```