### PR TITLE
Dockerfile for ubuntu

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,7 @@
+FROM golang:1.16-bullseye
+
+WORKDIR /go/src/github.com/jpbetz/auger
+ADD     . /go/src/github.com/jpbetz/auger
+RUN     go get github.com/jpbetz/auger && chmod +x /go/bin/auger
+
+ENTRYPOINT ["/go/bin/auger"]


### PR DESCRIPTION
Since original `Dockerfile` compiles against alpine's musl it creates a binary unusable outside the container.
This `Dockerfile.ubuntu` builds a binary you can copy into your host without the need to install golang at all (which is desirable in a production etcd server).

```
$ sudo docker build . -t auger:latest -f Dockerfile.ubuntu
$ sudo docker run --rm --entrypoint cat auger:latest /go/bin/auger > auger
$ chmod +x ./auger
$ ./auger -h
```