### PR TITLE
Create GH actions pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,65 @@
+name: Release Artifacts
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [created]
+
+permissions:
+  contents: 'write'
+  id-token: 'write'
+
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux]
+        goarch: [amd64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: Build
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -v ./...
+
+      - name: Test
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go test -v ./...
+
+  release:
+    if: github.event_name == 'release' && github.event.action == 'created'
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: Build
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o out/auger main.go
+      
+      - name: package
+        run: |
+          tar -czvf auger-${{matrix.goos}}-${{matrix.goarch}}.tar.gz out/
+      
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          gh release upload ${{github.ref_name}} auger-${{matrix.goos}}-${{matrix.goarch}}.tar.gz


### PR DESCRIPTION
I found myself not having binaries when I needed them, so I drafted this: It runs builds on `main` (linux+amd64 seems to be the only arch/platform combination that executes tests successfully, builds work for all platform/arch combinations I've tried) and if a release is created, it runs on the given tag and publishes the artifacts for each platform into the release.

Is this something that could be useful? Needed? 